### PR TITLE
Fix LLM response handling and filter normalization

### DIFF
--- a/backend/src/services/openai_service.py
+++ b/backend/src/services/openai_service.py
@@ -4,7 +4,7 @@ import time
 from ..cache import LRUCache
 from logging import Logger
 from openai import OpenAI
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 from ..model.pineconeQueryResponse import PineconeSearchResult
 
@@ -78,7 +78,7 @@ def generate_llm_response(
     search_query: str,
     top_k_results: List[PineconeSearchResult],
     results_cache: LRUCache,
-) -> Tuple[str, LRUCache]:
+) -> Tuple[Optional[str], LRUCache]:
     prompt = get_prompt(search_query, top_k_results)
     hashed_prompt = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
 
@@ -102,7 +102,7 @@ def generate_llm_response(
             "Could not generate answer to user query based on snippets",
             extra={"request_time": request_time},
         )
-        return None
+        return None, results_cache
     logger.info(
         "Successfully generated LLM response",
         extra={"request_time": request_time},

--- a/backend/src/services/pinecone_service.py
+++ b/backend/src/services/pinecone_service.py
@@ -4,7 +4,7 @@ from ..model.searchQuery import Filter
 from ..model.searchResponse import SearchResult
 
 from logging import Logger
-from typing import List
+from typing import List, Optional
 from pydantic_core import ValidationError
 
 
@@ -49,8 +49,10 @@ def group_results(
     return [groups[doc_id] for doc_id in doc_order]
 
 
-def normalize_filters(filter: List[Filter]) -> List[Filter]:
+def normalize_filters(filter: Optional[Filter]) -> Filter:
     f = Filter()
+    if not filter:
+        return f
     if filter.company:
         f.company = filter.company.lower()
     if filter.quarter:


### PR DESCRIPTION
## Summary
- return cached object when LLM response has no insights
- normalize search filters correctly and support missing values

## Testing
- `pytest -q` *(fails: `pytest` not installed)*