### PR TITLE
Fix snippet truncation

### DIFF
--- a/scraper/utils/text_util.py
+++ b/scraper/utils/text_util.py
@@ -89,14 +89,33 @@ def generate_snippet(
             if len(snippet) > max_chars:
                 snippet = snippet[:max_chars].rsplit(" ", 1)[0] + "..."
             return snippet
-    # Fallback: take sentences in order until limit
+    # Fallback: take sentences in order until limit. If we cannot include an
+    # entire sentence because it would exceed ``max_chars`` we truncate on a
+    # word boundary and append an ellipsis so callers know the text was
+    # shortened.
     snippet = ""
-    for sentence in sentences:
-        if len(snippet) + len(sentence) + 1 <= max_chars:
-            snippet += sentence + " "
+    truncated = False
+    for idx, sentence in enumerate(sentences):
+        sep = " " if snippet else ""
+        if len(snippet) + len(sep) + len(sentence) <= max_chars:
+            snippet += sep + sentence
         else:
+            remaining = max_chars - len(snippet) - 3
+            if remaining > 0:
+                snippet += sep + sentence[:remaining]
+                snippet = snippet.rstrip().rsplit(" ", 1)[0]
+            truncated = True
             break
-    return snippet.strip()
+    else:
+        if idx < len(sentences) - 1:
+            truncated = True
+
+    snippet = snippet.strip()
+    if truncated:
+        if len(snippet) + 3 > max_chars:
+            snippet = snippet[: max_chars - 3].rsplit(" ", 1)[0]
+        snippet = snippet.rstrip() + "..."
+    return snippet
 
 
 def generate_snippets(


### PR DESCRIPTION
## Summary
- prevent overflow when truncating snippets

## Testing
- ❌ `pytest -q` *(fails: `pytest: command not found`)*