### PR TITLE
Fix get_new_transcript_urls call

### DIFF
--- a/scraper/crawler_manager.py
+++ b/scraper/crawler_manager.py
@@ -78,7 +78,7 @@ def get_new_transcript_urls(dry_run: bool = False, force: bool = False) -> List[
 
 
 def get_urls_and_store(force: bool = False) -> List[str]:
-    new_urls = get_new_transcript_urls(force)
+    new_urls = get_new_transcript_urls(force=force)
     store_crawled_urls(new_urls)
     return new_urls
 


### PR DESCRIPTION
## Summary
- fix `get_urls_and_store` call signature to pass force as keyword

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*