### PR TITLE
Fix path references in ticker loader

### DIFF
--- a/common/load_tickers.py
+++ b/common/load_tickers.py
@@ -4,13 +4,13 @@ from pathlib import Path
 
 def load_ticker_metadata() -> dict[str, dict[str, str]]:
     """
-    Load ticker metadata from shared_data/tickers.json.
+    Load ticker metadata from common/tickers.json.
 
     Returns:
         A dictionary mapping ticker symbols (e.g., 'AAPL') to their metadata,
         e.g. { 'exchange': 'NASDAQ', 'name': 'Apple Inc.' }.
     """
-    # Determine path to shared_data/tickers.json based on project root
+    # Determine path to common/tickers.json based on project root
     repo_root = Path(__file__).resolve().parents[1]
     json_path = repo_root / "common" / "tickers.json"
 


### PR DESCRIPTION
## Summary
- fix references to the ticker metadata json path

## Testing
- `pytest -q` *(fails: command not found)*