### PR TITLE
Add utility module tests

### DIFF
--- a/scraper/utils/io.py
+++ b/scraper/utils/io.py
@@ -52,6 +52,7 @@ def get_cached_instrument_id(ticker: str) -> Optional[str]:
         with open(fn, "r") as f:
             data = json.load(f)
         return data.get(ticker, "")
+    return ""
 
 
 def store_instrument_id(ticker: str, instrument_id: str):

--- a/scraper/utils/test_io.py
+++ b/scraper/utils/test_io.py
@@ -1,0 +1,55 @@
+import json
+from datetime import datetime, timezone
+from scraper.utils.io import (
+    load_url_store,
+    write_url_store,
+    record_url_metadata,
+    mark_url_as_scraped,
+    get_cached_instrument_id,
+    store_instrument_id,
+    pick_useragent,
+    read_last_crawled,
+    store_last_crawled,
+)
+
+
+def test_record_and_mark_url(tmp_path, monkeypatch):
+    store_path = tmp_path / "store.json"
+    monkeypatch.setenv("DEFAULT_STORE_PATH", str(store_path))
+
+    record_url_metadata("http://example.com", {"foo": "bar"})
+    data = json.loads(store_path.read_text())
+    assert data["http://example.com"]["foo"] == "bar"
+
+    mark_url_as_scraped("http://example.com")
+    data = json.loads(store_path.read_text())
+    assert data["http://example.com"]["status"] == "fetched"
+    assert "fetched_at" in data["http://example.com"]
+
+
+def test_instrument_id_cache(tmp_path, monkeypatch):
+    path = tmp_path / "ids.json"
+    monkeypatch.setenv("INSTRUMENT_ID_PATH", str(path))
+
+    assert get_cached_instrument_id("AAPL") == ""
+    store_instrument_id("AAPL", "123")
+    assert get_cached_instrument_id("AAPL") == "123"
+
+
+def test_pick_useragent(tmp_path, monkeypatch):
+    path = tmp_path / "ua.json"
+    json.dump(["UA1", "UA2"], path.open("w"))
+    monkeypatch.setenv("USERAGENT_PATH", str(path))
+    assert pick_useragent() in ["UA1", "UA2"]
+
+
+def test_last_crawled(tmp_path, monkeypatch):
+    path = tmp_path / "recency.json"
+    monkeypatch.setenv("RECENCY_PATH", str(path))
+
+    now = datetime.now(timezone.utc)
+    store_last_crawled("AAPL", now)
+    data = read_last_crawled()
+    assert "AAPL" in data
+    delta = abs((data["AAPL"] - now).total_seconds())
+    assert delta < 1

--- a/scraper/utils/test_report.py
+++ b/scraper/utils/test_report.py
@@ -1,0 +1,19 @@
+import json
+from scraper.utils.report import save_skipped_slugs, save_problematic_urls
+
+
+def test_save_skipped_slugs(tmp_path):
+    slugs = {"a", "b"}
+    save_skipped_slugs(slugs, reason="test", output_dir=str(tmp_path))
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    content = set(files[0].read_text().splitlines())
+    assert content == slugs
+
+
+def test_save_problematic_urls(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    save_problematic_urls({"u": "err"})
+    path = tmp_path / "data" / "skipped" / "problematic_urls.json"
+    data = json.loads(path.read_text())
+    assert data == {"u": "err"}

--- a/scraper/utils/test_storage_utils.py
+++ b/scraper/utils/test_storage_utils.py
@@ -1,0 +1,20 @@
+from scraper.utils.storage import TranscriptKey, LocalStorage
+
+def test_transcriptkey_conversions():
+    tk = TranscriptKey('AAPL', 'Q1', 2024)
+    slug = tk.slug()
+    assert slug == 'aapl-q1-2024'
+    path = tk.to_path('data')
+    assert path.endswith('data/html/aapl/q1-2024.html')
+    assert TranscriptKey.from_slug(slug).slug() == slug
+    assert TranscriptKey.from_path(path).slug() == slug
+    url = 'https://example.com/foo-aapl-q1-2024-bar'
+    assert TranscriptKey.from_url(url).slug() == slug
+
+def test_localstorage_roundtrip(tmp_path):
+    tk = TranscriptKey('MSFT', 'Q2', 2023)
+    store = LocalStorage(data_root=str(tmp_path))
+    store.write_html(tk, 'hello')
+    assert store.read_html(tk) == 'hello'
+    saved = tmp_path / 'html' / 'msft' / 'q2-2023.html'
+    assert saved.exists() and saved.read_text(encoding='utf-8') == 'hello'

--- a/scraper/utils/test_time_util.py
+++ b/scraper/utils/test_time_util.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timedelta, timezone
+from scraper.utils.time_util import now_utc_iso, is_older_than_a_week, time_block, polite_sleep
+
+
+def test_now_utc_iso_has_timezone():
+    ts = now_utc_iso()
+    dt = datetime.fromisoformat(ts)
+    assert dt.tzinfo is not None
+
+
+def test_is_older_than_a_week():
+    old = datetime.now(tz=timezone.utc) - timedelta(days=8)
+    recent = datetime.now(tz=timezone.utc) - timedelta(days=6)
+    assert is_older_than_a_week(old)
+    assert not is_older_than_a_week(recent)
+
+
+def test_time_block_decorator(capsys):
+    @time_block("test")
+    def add(a, b):
+        return a + b
+
+    result = add(1, 2)
+    out = capsys.readouterr().out
+    assert result == 3
+    assert "Starting: test" in out
+    assert "Finished test" in out
+
+
+def test_polite_sleep_decorator():
+    calls = []
+
+    @polite_sleep(min_delay=0, max_delay=0)
+    def foo(x):
+        calls.append(x)
+        return x
+
+    assert foo(42) == 42
+    assert calls == [42]


### PR DESCRIPTION
## Summary
- add tests for storage helper conversion
- cover time utilities like `time_block`
- add tests for persistence helpers in `io`
- exercise reporting helpers

## Testing
- `pytest -q` *(fails: command not found)*
- `python3 -m pytest -q` *(fails: No module named pytest)*