### PR TITLE
Fix Vercel analytics import in frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { Analytics } from "@vercel/analytics/next"
+import { Analytics } from "@vercel/analytics/react"
 import './App.css'
 import axios from 'axios'
 


### PR DESCRIPTION
## Summary
- correct import path for Vercel analytics to use the React package

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*