### PR TITLE
Add ingestion pipeline timing profiler

### DIFF
--- a/scraper/utils/report.py
+++ b/scraper/utils/report.py
@@ -1,7 +1,30 @@
 import json
+from contextlib import contextmanager
+from time import perf_counter
 
 from datetime import datetime
 from pathlib import Path
+
+
+class PipelineProfiler:
+    """Record durations for pipeline steps."""
+
+    def __init__(self):
+        self.report = {
+            "steps": {},
+            "started_at": datetime.utcnow().isoformat(),
+        }
+
+    @contextmanager
+    def record(self, step: str):
+        start = perf_counter()
+        yield
+        self.report["steps"][step] = perf_counter() - start
+
+    def finish(self) -> dict:
+        self.report["ended_at"] = datetime.utcnow().isoformat()
+        self.report["total_runtime_seconds"] = sum(self.report["steps"].values())
+        return self.report
 
 
 def print_run_report(report):
@@ -55,6 +78,22 @@ def save_ingest_report(report: dict, mode: str = "ingest"):
         json.dump(report, f, indent=2)
 
     print(f"📝 Saved ingestion report to {path}")
+
+
+def print_pipeline_report(report: dict):
+    print("\n⏳ Pipeline Timing Report")
+    for step, dur in report.get("steps", {}).items():
+        print(f"  {step}: {dur:.2f}s")
+    print(f"  Total: {report.get('total_runtime_seconds', 0.0):.2f}s")
+
+
+def save_pipeline_report(report: dict, path_prefix: str = "data/logs/"):
+    dt = datetime.utcnow().strftime("%Y-%m-%dT%H-%M-%S")
+    Path(path_prefix).mkdir(parents=True, exist_ok=True)
+    path = Path(path_prefix) / f"pipeline_report_{dt}.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+    print(f"📝 Saved pipeline report to {path}")
 
 
 def save_problematic_urls(urls):

--- a/scraper/utils/test_report.py
+++ b/scraper/utils/test_report.py
@@ -1,5 +1,10 @@
 import json
-from scraper.utils.report import save_skipped_slugs, save_problematic_urls
+from scraper.utils.report import (
+    save_skipped_slugs,
+    save_problematic_urls,
+    PipelineProfiler,
+    save_pipeline_report,
+)
 
 
 def test_save_skipped_slugs(tmp_path):
@@ -17,3 +22,17 @@ def test_save_problematic_urls(tmp_path, monkeypatch):
     path = tmp_path / "data" / "skipped" / "problematic_urls.json"
     data = json.loads(path.read_text())
     assert data == {"u": "err"}
+
+
+def test_pipeline_profiler_and_save(tmp_path):
+    profiler = PipelineProfiler()
+    with profiler.record("test"):
+        pass
+    report = profiler.finish()
+    assert "test" in report["steps"]
+    assert report["total_runtime_seconds"] >= 0
+    save_pipeline_report(report, path_prefix=str(tmp_path) + "/")
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    saved = json.loads(files[0].read_text())
+    assert saved["steps"] == report["steps"]


### PR DESCRIPTION
## Summary
- introduce `PipelineProfiler` and pipeline report helpers
- track embed and upsert durations in `ChunkProcessor`
- refactor ingestion logic and add `profile` CLI step
- extend tests for new reporting utilities

## Testing
- `pytest -q` *(fails: command not found)*