### PR TITLE
Add linters to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,4 +6,9 @@ repos:
         entry: ./scripts/run_changed_tests.sh
         language: script
         pass_filenames: false
+      - id: run-changed-linters
+        name: Run linters for changed directories
+        entry: ./scripts/run_changed_linters.sh
+        language: script
+        pass_filenames: false
 

--- a/README.md
+++ b/README.md
@@ -83,12 +83,15 @@ Verify the backend is running by hitting `http://localhost:8000/healthz`. It ret
 
 ## Pre-commit Hook
 This repository uses [pre-commit](https://pre-commit.com/) to automatically run
-unit tests on directories with staged changes. Install the hook with:
+unit tests and linters on directories with staged changes. Install the hook with:
 
 ```bash
 pre-commit install
 ```
 
-Before each commit, `pytest` will run for any top-level directory that contains
-tests and has staged modifications (e.g. `backend`, `scraper`). If no such
-changes are present, the hook exits without running tests.
+Before each commit, `pytest` runs for any top-level directory that contains
+tests and has staged modifications (e.g. `backend`, `scraper`). When code in
+`backend`, `scraper`, `common`, or `setup.py` changes, `black` checks the files.
+If the `frontend` directory has modifications, ESLint runs. If none of these
+directories have staged changes, the hook exits without running tests or
+linters.

--- a/scripts/run_changed_linters.sh
+++ b/scripts/run_changed_linters.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+changed_files=$(git diff --cached --name-only --diff-filter=ACM)
+
+python_changed=false
+frontend_changed=false
+
+for file in $changed_files; do
+    top_dir="${file%%/*}"
+    case "$top_dir" in
+        backend|scraper|common)
+            python_changed=true
+            ;;
+        frontend)
+            frontend_changed=true
+            ;;
+        *)
+            if [[ "$file" == "setup.py" ]]; then
+                python_changed=true
+            fi
+            ;;
+    esac
+    if [[ "$python_changed" = true && "$frontend_changed" = true ]]; then
+        break
+    fi
+done
+
+if [[ "$python_changed" = false && "$frontend_changed" = false ]]; then
+    echo "No linting required."
+    exit 0
+fi
+
+if [[ "$python_changed" = true ]]; then
+    echo "Running black..."
+    black --check backend scraper common setup.py
+fi
+
+if [[ "$frontend_changed" = true ]]; then
+    echo "Running ESLint..."
+    npm run lint --prefix frontend
+fi


### PR DESCRIPTION
## Summary
- run black or ESLint during pre-commit depending on changed directories
- wire new script into pre-commit config
- document the linting in README

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: command not found)*