### PR TITLE
Fix LRUCache zero capacity handling

### DIFF
--- a/backend/src/cache.py
+++ b/backend/src/cache.py
@@ -29,6 +29,8 @@ class LRUCache:
         self.map[k] = node
 
     def _delete(self, n: Node):
+        if n is self.head or n is self.tail:
+            return
         n.left.right = n.right
         n.right.left = n.left
         del self.map[n.key]
@@ -42,6 +44,8 @@ class LRUCache:
         return
 
     def set(self, k: Any, v: Any):
+        if self.capacity <= 0:
+            return
         if len(self.map) >= self.capacity:
             self._delete(self.tail.left)
         if self.map.get(k):

--- a/backend/src/test_cache.py
+++ b/backend/src/test_cache.py
@@ -34,3 +34,9 @@ def test_lru_ordering():
     assert cache.get("b") is None
     assert cache.get("a") == 1
     assert cache.get("c") == 3
+
+
+def test_lru_zero_capacity():
+    cache = LRUCache(capacity=0)
+    cache.set("a", 1)
+    assert cache.get("a") is None


### PR DESCRIPTION
## Summary
- prevent `_delete` from removing sentinel nodes
- no-op `set` when cache capacity is zero
- add unit test for zero capacity

## Testing
- `python -m pytest backend` *(fails: No module named pytest)*