### PR TITLE
Remove tests from setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Python dependencies
+python3 -m pip install --upgrade pip
+python3 -m pip install -r backend/requirements.txt
+python3 -m pip install -r scraper/requirements.txt
+python3 -m pip install -e .
+
+# Install frontend dependencies
+cd frontend && npm ci && cd ..
+
+


### PR DESCRIPTION
## Summary
- update `setup.sh` to only install dependencies

## Testing
- `pre-commit run --files setup.sh` *(fails: `pre-commit: command not found`)*