### PR TITLE
Set min machines to zero

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -14,7 +14,7 @@ primary_region = 'iad'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
   processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
## Summary
- reduce min_machines_running to 0 in Fly config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876bffb8904832496e7aac1ea8a43af